### PR TITLE
add the securityRequirements and securitySchemes to the API contract

### DIFF
--- a/beer-catalog-demo/api-contracts/beer-catalog-api-swagger.json
+++ b/beer-catalog-demo/api-contracts/beer-catalog-api-swagger.json
@@ -139,5 +139,17 @@
         }
       }
     }
-  }
+  },
+  "securityDefinitions": {
+    "api-key": {
+      "type": "apiKey",
+      "name": "api-key",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "api-key": []
+    }
+  ]
 }


### PR DESCRIPTION
To be usable in the CI/CD pipeline, the API contract needs securityRequirements and securitySchemes